### PR TITLE
Fix for AWS ELB issue

### DIFF
--- a/src/metabase/middleware/misc.clj
+++ b/src/metabase/middleware/misc.clj
@@ -43,7 +43,7 @@
 (defn- maybe-set-site-url* [{{:strs [origin x-forwarded-host host] :as headers} :headers, :as request}]
   (when (and (mdb/db-is-setup?)
              (not (public-settings/site-url))
-             api/*current-user*)
+             api/*current-user* ((complement clojure.string/includes?) user-agent "HealthChecker")); Not setting URL if it's a healthcheck by ELB
     (when-let [site-url (or origin x-forwarded-host host)]
       (log/info (trs "Setting Metabase site URL to {0}" site-url))
       (try


### PR DESCRIPTION
When Metabase is deployed to AWS behind ELB the very first call to it is made by ELB health check. Out of `origin`, `x-forwarded-host`,  `host` in this case only `host` is populated and it is populated with internal private IP. This causes `site-url` to be populated with URL with private IP in it. The fix is checks for caller user agent and if it contains "HealthChecker" - does not set `site-url` at this time